### PR TITLE
Hidden pair rule for shorter ASTs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -28,7 +28,7 @@ module.exports = grammar({
       ),
 
     _section: ($) => choice($.map, $.list),
-    map: ($) => seq($.pair, repeat(seq($._newline, $.pair))),
+    map: ($) => seq($._pair, repeat(seq($._newline, $._pair))),
     list: ($) => seq($._item, repeat(seq($._newline, $._item))),
 
     _space: ($) => /[ \t]+/,
@@ -97,7 +97,7 @@ module.exports = grammar({
         ),
       ),
 
-    pair: ($) =>
+    _pair: ($) =>
       seq(
         $.key,
         choice(

--- a/test/corpus/lists.txt
+++ b/test/corpus/lists.txt
@@ -7,11 +7,10 @@ List
 
 ---
 
-
 (source_file
-    (list
-      (value)
-      (value)))
+  (list
+    (value)
+    (value)))
 
 ==================
 Nested Lists
@@ -23,9 +22,9 @@ Nested Lists
 ---
 
 (source_file
+  (list
     (list
-    (list
-        (value))))
+      (value))))
 
 ==================
 Maps in Lists
@@ -41,13 +40,11 @@ Maps in Lists
 (source_file
   (list
     (map
-      (pair
-        (key)
-        (value)))
+      (key)
+      (value))
     (map
-      (pair
-        (key)
-        (value)))))
+      (key)
+      (value))))
 
 ==================
 Lists in Maps
@@ -62,14 +59,12 @@ b =
 
 (source_file
   (map
-    (pair
-      (key)
-      (list
-        (value)))
-    (pair
-      (key)
-      (list
-        (value)))))
+    (key)
+    (list
+      (value))
+    (key)
+    (list
+      (value))))
 
 ==================
 Lists with comments
@@ -80,6 +75,7 @@ Lists with comments
 = b ;asd
 
 ---
+
 (source_file
   (list
     (comment)
@@ -99,8 +95,12 @@ Lists with multiline
   end
 
 ---
+
 (source_file
-    (list
-    (multiline_value (comment) (multiline_content))
+  (list
     (multiline_value
-        (multiline_hint) (multiline_content))))
+      (comment)
+      (multiline_content))
+    (multiline_value
+      (multiline_hint)
+      (multiline_content))))

--- a/test/corpus/map.txt
+++ b/test/corpus/map.txt
@@ -17,12 +17,10 @@ b = b
 
 (source_file
   (map
-    (pair
-        (key)
-        (value))
-    (pair
-        (key)
-        (value))))
+    (key)
+    (value)
+    (key)
+    (value)))
 
 ==================
 Nested Map
@@ -36,12 +34,10 @@ a
 
 (source_file
   (map
-    (pair
-        (key)
-        (map
-        (pair
-            (key)
-            (value))))))
+    (key)
+    (map
+      (key)
+      (value))))
 
 ==================
 Nested Closed
@@ -55,16 +51,12 @@ c = c
 
 (source_file
   (map
-    (pair
-        (key)
-        (map
-            (pair
-                (key)
-                (value)))
-        )
-    (pair
-        (key)
-        (value))))
+    (key)
+    (map
+      (key)
+      (value))
+    (key)
+    (value)))
 
 ==================
 Nested Double Closed
@@ -79,20 +71,14 @@ d = d
 
 (source_file
   (map
-    (pair
+    (key)
+    (map
+      (key)
+      (map
         (key)
-        (map
-            (pair
-                (key)
-                (map
-                    (pair
-                    (key)
-                    (value)))
-                ))
-        )
-    (pair
-        (key)
-        (value))))
+        (value)))
+    (key)
+    (value)))
 
 ==================
 Nested Half Closed
@@ -107,20 +93,14 @@ a
 
 (source_file
   (map
-    (pair
+    (key)
+    (map
+      (key)
+      (map
         (key)
-        (map
-            (pair
-                (key)
-                (map
-                    (pair
-                    (key)
-                    (value)))
-                )
-            (pair
-                (key)
-                (value)))
-        )))
+        (value))
+      (key)
+      (value))))
 
 ==================
 Empties
@@ -133,10 +113,8 @@ b
 
 (source_file
   (map
-    (pair
-        (key))
-    (pair
-        (key))))
+    (key)
+    (key)))
 
 ==================
 Commentier
@@ -154,15 +132,13 @@ a
 (source_file
   (line_comment)
   (map
-    (pair
-        (key)
-        (map
-            (pair
-                (key)
-                (line_comment)
-                    (list (value)
-            (line_comment))))
-        )))
+    (key)
+    (map
+      (key)
+      (line_comment)
+      (list
+        (value)
+        (line_comment)))))
 
 ==================
 Inline comments
@@ -176,24 +152,18 @@ a ; a
 d =;
   ;
 ---
+
 (source_file
+  (map
+    (key)
+    (comment)
     (map
-    (pair
+      (key)
+      (comment)
+      (map
         (key)
-        (comment)
-        (map
-        (pair
-            (key)
-            (comment)
-            (map
-            (pair
-                (key)
-                (value)
-                (comment)))
-            ))
-        )
-    (pair
-        (key)
-        (comment)
-        (line_comment)
-        )))
+        (value)
+        (comment)))
+    (key)
+    (comment)
+    (line_comment)))

--- a/test/corpus/values.txt
+++ b/test/corpus/values.txt
@@ -8,17 +8,15 @@ Quoted
 ---
 
 (source_file
-    (map
-    (pair
-        (key
-            (escape_sequence)
-            (escape_sequence))
-        (value
-          (escape_sequence)))
-    (pair
-        (key
-            (escape_sequence))
-        (value))))
+  (map
+    (key
+      (escape_sequence)
+      (escape_sequence))
+    (value
+      (escape_sequence))
+    (key
+      (escape_sequence))
+    (value)))
 
 ==================
 Comments
@@ -30,15 +28,13 @@ b = a ;
 ---
 
 (source_file
-    (map
-    (pair
-        (key)
-        (value)
-        (comment))
-    (pair
-        (key)
-        (value)
-        (comment))))
+  (map
+    (key)
+    (value)
+    (comment)
+    (key)
+    (value)
+    (comment)))
 
 ==================
 Comments & Quotes
@@ -56,32 +52,27 @@ Comments & Quotes
 ---
 
 (source_file
+  (map
+    (key)
+    (value)
+    (comment)
+    (key)
+    (comment)
     (map
-    (pair
-        (key)
-        (value)
-        (comment))
-    (pair
-        (key)
+      (key)
+      (multiline_value
         (comment)
-        (map
-        (pair
-            (key)
-            (multiline_value
-            (comment)
-            (multiline_content)))
-        (pair
-            (key)
-            (multiline_value
-            (multiline_hint)
-            (comment)
-            (multiline_content)))
-        (pair
-            (key)
-            (multiline_value
-            (multiline_hint)
-            (comment)
-            (multiline_content)))))))
+        (multiline_content))
+      (key)
+      (multiline_value
+        (multiline_hint)
+        (comment)
+        (multiline_content))
+      (key)
+      (multiline_value
+        (multiline_hint)
+        (comment)
+        (multiline_content)))))
 
 ==================
 Multiline
@@ -93,11 +84,10 @@ a = """
 ---
 
 (source_file
-    (map
-    (pair
-        (key)
-        (multiline_value (multiline_content)))))
-
+  (map
+    (key)
+    (multiline_value
+      (multiline_content))))
 
 ==================
 Multiline nesting
@@ -113,13 +103,12 @@ b = c
 ---
 
 (source_file
-    (map
-    (pair
-        (key)
-        (multiline_value (multiline_content)))
-    (pair
-        (key)
-        (value))))
+  (map
+    (key)
+    (multiline_value
+      (multiline_content))
+    (key)
+    (value)))
 
 ==================
 Multiline indicators
@@ -133,14 +122,12 @@ a = """bash ;wow
 ---
 
 (source_file
-    (map
-    (pair
-        (key)
-        (multiline_value
-            (multiline_hint)
-            (comment)
-            (multiline_content)
-            ))))
+  (map
+    (key)
+    (multiline_value
+      (multiline_hint)
+      (comment)
+      (multiline_content))))
 
 ==================
 Multiline Indicators More
@@ -154,13 +141,11 @@ a = """ ba_sh
 ---
 
 (source_file
-    (map
-    (pair
-        (key)
-        (multiline_value
-            (multiline_hint)
-            (multiline_content)
-            ))))
+  (map
+    (key)
+    (multiline_value
+      (multiline_hint)
+      (multiline_content))))
 
 ==================
 Multiline Comments
@@ -173,10 +158,8 @@ a = """
 ---
 
 (source_file
-    (map
-    (pair
-        (key)
-        (multiline_value
-            (multiline_content))
-        (line_comment)
-            )))
+  (map
+    (key)
+    (multiline_value
+      (multiline_content))
+    (line_comment)))


### PR DESCRIPTION
Substituted in the grammar.js file the `pair` rule with the `_pair` rule and updated the tests.